### PR TITLE
fix(plugin-shield): format of `rules` for plugin-shield

### DIFF
--- a/plugins-prisma-and-jwt-auth-and-shield/api/permissions/index.ts
+++ b/plugins-prisma-and-jwt-auth-and-shield/api/permissions/index.ts
@@ -14,7 +14,7 @@ const rules = {
         filterPosts: isAuthenticated,
         post: isAuthenticated
     },
-    Mutations: {
+    Mutation: {
         createDraft: isAuthenticated,
         deletePost: isAuthenticated,
         publish: isAuthenticated


### PR DESCRIPTION
It seems it must be `Mutation` instead of `Mutations` in `rules` for `nexus-plugin-shield`.

https://github.com/maticzav/graphql-shield